### PR TITLE
Track usage activity for OpenAIRE usage statistics service

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/matomo/openaire/OpenAIREMatomoEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/matomo/openaire/OpenAIREMatomoEventListener.java
@@ -1,0 +1,251 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.statistics.matomo.openaire;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.services.model.Event;
+import org.dspace.usage.AbstractUsageEventListener;
+import org.dspace.usage.UsageEvent;
+
+public class OpenAIREMatomoEventListener extends AbstractUsageEventListener {
+    private static final Logger log = LogManager.getLogger(OpenAIREMatomoEventListener.class);
+    private ObjectMapper objectMapper;
+    private boolean matomoIsEnabled;
+    private String matomoUrl;
+    private String matomoSiteID;
+    private String matomoAuthToken;
+    private int matomoBulkRequestSize;
+    private int matomoIPAnonymizationBytes;
+    private String dspaceURL;
+    private boolean useProxies;
+    private CloseableHttpClient httpClient;
+    private final Queue<Map<String, String>> queue = new ConcurrentLinkedQueue<>();
+
+    @PostConstruct
+    public void init() {
+        objectMapper = new ObjectMapper();
+        ConfigurationService configService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        matomoIsEnabled = configService.getBooleanProperty("matomo.openaire.analytics.enabled", false);
+        matomoUrl = configService.getProperty("matomo.openaire.analytics.trackerURL");
+        matomoSiteID = configService.getProperty("matomo.openaire.analytics.siteID");
+        matomoAuthToken = configService.getProperty("matomo.openaire.analytics.authToken");
+        matomoBulkRequestSize = configService.getIntProperty("matomo.openaire.analytics.bulk_request_size");
+        matomoIPAnonymizationBytes = configService.getIntProperty("matomo.openaire.analytics.ipAnonymizationBytes");
+
+        dspaceURL = configService.getProperty("dspace.ui.url");
+        useProxies = configService.getPropertyAsType("useProxies", false);
+        httpClient = HttpClients.createDefault();
+    }
+
+    @Override
+    public void receiveEvent(final Event event) {
+        if (!(event instanceof UsageEvent) || !matomoIsEnabled || httpClient == null) {
+            return;
+        }
+
+        UsageEvent ue = (UsageEvent) event;
+        if (ue.getAction() == UsageEvent.Action.VIEW) {
+            processViewEvent(ue);
+        }
+    }
+
+    private void processViewEvent(UsageEvent ue) {
+        try {
+            if (ue.getObject().getType() == Constants.BITSTREAM) {
+                processBitstreamView(ue);
+            } else if (ue.getObject().getType() == Constants.ITEM) {
+                processItemView((Item) ue.getObject(), ue.getRequest());
+            }
+        } catch (URISyntaxException e) {
+            log.error("Error constructing OpenAIRE request URL", e);
+        }
+    }
+
+    private void processBitstreamView(UsageEvent ue) {
+        Bitstream bitstream = (Bitstream) ue.getObject();
+        try {
+            if (!bitstream.getBundles().isEmpty()) {
+                Bundle bundle = bitstream.getBundles().get(0);
+                if (!bundle.getItems().isEmpty()) {
+                    Item item = bundle.getItems().get(0);
+                    logEvent(item, bitstream, ue.getRequest());
+                }
+            }
+        } catch (SQLException | URISyntaxException e) {
+            throw new RuntimeException("Error in processing bitstream view " + e.getMessage());
+        }
+    }
+
+    private void processItemView(Item item, HttpServletRequest request) throws URISyntaxException {
+        logEvent(item, null, request);
+    }
+
+    private void logEvent(Item item, Bitstream bitstream, HttpServletRequest request) throws URISyntaxException {
+        buildMatomoRequest(item, bitstream, request);
+        if (queue.size() >= matomoBulkRequestSize) {
+            sendBulkRequest();
+        }
+    }
+
+    private synchronized void buildMatomoRequest(Item item, Bitstream bitstream, HttpServletRequest httpRequest) {
+        Map<String, String> matomoRequest = new HashMap<>();
+        matomoRequest.put("idsite", matomoSiteID);
+        matomoRequest.put("cip", this.getIPAddress(httpRequest));
+
+        // Country information in case of IPAnonymization
+        if (matomoIPAnonymizationBytes > 0 && matomoIPAnonymizationBytes < 4) {
+            String country = "";
+            try {
+                Locale locale = httpRequest.getLocale();
+                country = locale.getCountry();
+            } catch (Exception e) {
+                log.error("Cannot get locale", e);
+            }
+            matomoRequest.put("country", country);
+        }
+
+        matomoRequest.put("rec", "1");
+        matomoRequest.put("action_name", item.getName());
+        matomoRequest.put("ua", StringUtils.defaultIfBlank(httpRequest.getHeader("USER-AGENT"), ""));
+        matomoRequest.put("urlref", StringUtils.defaultIfBlank(httpRequest.getHeader("referer"), ""));
+
+        String trackingUrl = dspaceURL + (bitstream != null
+                ? "/bitstreams/" + bitstream.getID() + "/download"
+                : "/items/" + item.getID());
+        matomoRequest.put("url", trackingUrl);
+        if (bitstream != null) {
+            matomoRequest.put("download", trackingUrl);
+        }
+
+        Map<String, String[]> customVars = new HashMap<>();
+        customVars.put("1", new String[]{"oaipmhID", "oai:" + dspaceURL + ":" + item.getHandle()});
+        matomoRequest.put("cvar", new Gson().toJson(customVars));
+
+        queue.add(matomoRequest);
+    }
+
+    private void sendBulkRequest() {
+        if (queue.isEmpty()) {
+            return;
+        }
+
+        List<Map<String, String>> bulkRequests = new ArrayList<>();
+        while (!queue.isEmpty() && bulkRequests.size() < matomoBulkRequestSize) {
+            bulkRequests.add(queue.poll());
+        }
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("requests", bulkRequests);
+        requestBody.put("token_auth", matomoAuthToken);
+
+        try {
+            String jsonPayload = objectMapper.writeValueAsString(requestBody);
+
+            HttpPost request = new HttpPost(matomoUrl);
+            request.setHeader("Content-Type", "application/json");
+            request.setEntity(new StringEntity(jsonPayload));
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                String jsonResponse = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                log.info("Matomo Response: {}", jsonResponse);
+            }
+        } catch (IOException e) {
+            log.error("request to Matomo failed: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Get the IP-Address from the given request. Handles cases where a Proxy is
+     * involved and IP-Address anonymization. Not yet working with IPv6
+     */
+    private String getIPAddress(final HttpServletRequest request) {
+        String clientIP = request.getRemoteAddr();
+        if (useProxies && request.getHeader("X-Forwarded-For") != null) {
+            for (String xfip : request.getHeader("X-Forwarded-For").split(",")) {
+                /*
+                 * proxy itself will sometime populate this header with the same
+                 * value in remote address. ordering in spec is vague, we'll
+                 * just take the last not equal to the proxy
+                 */
+                if (!request.getHeader("X-Forwarded-For").contains(clientIP)) {
+                    clientIP = xfip.trim();
+                }
+            }
+        }
+
+        // IP anonymization case
+        if (matomoIPAnonymizationBytes > 0 && matomoIPAnonymizationBytes < 4) {
+            // Check IPv4 or IPv6
+            InetAddress ipadress = null;
+            try {
+                ipadress = InetAddress.getByName(clientIP);
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
+            if (ipadress instanceof Inet6Address) {
+                clientIP = "0.0.0.0";
+            } else {
+                switch (matomoIPAnonymizationBytes) {
+                    case 1:
+                        clientIP = clientIP.substring(0,
+                                StringUtils.ordinalIndexOf(clientIP, ".", 3))
+                                + ".0";
+                        break;
+                    case 2:
+                        clientIP = clientIP.substring(0,
+                                StringUtils.ordinalIndexOf(clientIP, ".", 2))
+                                + ".0.0";
+                        break;
+                    case 3:
+                        clientIP = clientIP.substring(0,
+                                StringUtils.ordinalIndexOf(clientIP, ".", 1))
+                                + ".0.0.0";
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                                "Invalid IP bytes: " + matomoIPAnonymizationBytes);
+                }
+            }
+        }
+
+        return clientIP;
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1643,6 +1643,7 @@ include = ${module_dir}/identifiers.cfg
 include = ${module_dir}/irus-statistics.cfg
 include = ${module_dir}/oai.cfg
 include = ${module_dir}/openaire-client.cfg
+include = ${module_dir}/openaire-matomo.cfg
 include = ${module_dir}/orcid.cfg
 include = ${module_dir}/rdf.cfg
 include = ${module_dir}/rest.cfg

--- a/dspace/config/modules/openaire-matomo.cfg
+++ b/dspace/config/modules/openaire-matomo.cfg
@@ -1,0 +1,24 @@
+#-----------------------------------#
+#----- OpenAIRE Matomo Tracker -----#
+#-----------------------------------#
+
+# Configure tracker parameters:
+
+# Enable (true) or disable (false) the tracker. Default value is false.
+matomo.openaire.analytics.enabled = true
+
+# OpenAIRE's Matomo URL (don't change it) (maybe first change piwik.php to matomo.php)
+matomo.openaire.analytics.trackerURL = https://analytics.openaire.eu/piwik.php
+
+# Set a valid siteId provided to you by OpenAIRE
+matomo.openaire.analytics.siteID = <your_matomo_siteId>
+
+# Set a valid auth token provided to you by OpenAIRE
+matomo.openaire.analytics.authToken = <your_matomo_auth_token>
+
+# Set the bulk request size, default value = 200
+matomo.openaire.analytics.bulk_request_size = 2
+
+# Optionally, specify the number of bytes in IP Address for IP Anonymization (for supported versions only)
+# IP Address Anonymization Bytes. Values in {1,2,3}
+# matomo.openaire.analytics.ipAnonymizationBytes = 2

--- a/dspace/config/spring/rest/event-service-listeners.xml
+++ b/dspace/config/spring/rest/event-service-listeners.xml
@@ -24,4 +24,8 @@
         <property name="eventService" ref="org.dspace.services.EventService"/>
     </bean>
 
+    <!-- OpenAIRE Matomo tracking  -->
+    <bean class="org.dspace.statistics.matomo.openaire.OpenAIREMatomoEventListener">
+        <property name="eventService" ref="org.dspace.services.EventService"/>
+    </bean>
 </beans>


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
